### PR TITLE
refactor: extract client-side logic into separate component

### DIFF
--- a/app/api/getNotionData/route.js
+++ b/app/api/getNotionData/route.js
@@ -1,8 +1,5 @@
 import { NextResponse } from 'next/server';
 import { Client } from '@notionhq/client';
-import { revalidatePath } from 'next/cache';
-
-export const revalidate = 100;
 
 export const revalidate = 100
 

--- a/app/components/ClientPage.tsx
+++ b/app/components/ClientPage.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import Hero from './Hero'
+import Services from './Services'
+import Work from './Work'
+import Contact from './Contact'
+import AskAI from './AskAI'
+
+const Scene3D = dynamic(() => import('./Scene3D'), {
+  ssr: false,
+  loading: () => <div className="fixed inset-0 bg-black -z-10" />,
+})
+
+export default function ClientPage() {
+  return (
+    <main className="relative">
+      <Scene3D />
+      <Hero />
+      <Services />
+      <Work />
+      <Contact />
+      <AskAI />
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,7 @@
-'use client'
-
-import dynamic from 'next/dynamic'
-import Hero from './components/Hero'
-import Services from './components/Services'
-import Work from './components/Work'
-import Contact from './components/Contact'
-import AskAI from './components/AskAI'
-
-const Scene3D = dynamic(() => import('./components/Scene3D'), {
-  ssr: false,
-  loading: () => <div className="fixed inset-0 bg-black -z-10" />,
-})
+import ClientPage from './components/ClientPage'
 
 export const revalidate = 100
+
 export default function Home() {
-  return (
-    <main className="relative">
-      <Scene3D />
-      <Hero />
-      <Services />
-      <Work />
-      <Contact />
-      <AskAI />
-    </main>
-  )
+  return <ClientPage />
 }


### PR DESCRIPTION
- Create new ClientPage component to handle client-side rendering
- Move 'use client' directive and all component imports to ClientPage
- Simplify page.tsx to server component that imports and renders ClientPage
- Remove duplicate revalidate export in getNotionData route
- Remove unused revalidatePath import from getNotionData route
- Improves separation of concerns between server and client components